### PR TITLE
Adding config changes to config tree builder

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,6 +21,7 @@ final class Configuration implements ConfigurationInterface
             ->scalarNode('api_key')->end()
             ->booleanNode('debug')->end()
             ->arrayNode('masked')->scalarPrototype()->end()
+            ->arrayNode('ignore')->scalarPrototype()->end()
             ->end();
 
         return $treeBuilder;


### PR DESCRIPTION
This PR fixes an oversight in the latest release, where the `ignore` option was not added to the configuration tree builder