### PR TITLE
fix: guard mask() against non-array decoded response body

### DIFF
--- a/src/DataProviders/SymfonyResponseDataProvider.php
+++ b/src/DataProviders/SymfonyResponseDataProvider.php
@@ -85,7 +85,7 @@ final class SymfonyResponseDataProvider implements ResponseDataProvider
             size: $size,
             load_time: $this->getLoadTimeInMilliseconds(),
             body: $masker->mask(
-                json_decode($body, true) ?? []
+                is_array($decoded = json_decode($body, true)) ? $decoded : []
             ),
             headers: $masker->mask($headers),
         );


### PR DESCRIPTION
## Summary

Fixes #21.

When the response body is a JSON-encoded scalar (string, number, boolean), `json_decode($body, true)` returns that scalar — not `null` — so the `?? []` fallback never fires and `SensitiveDataMasker::mask()` throws a `TypeError` because its `$data` parameter is typed `array`.

This guards with `is_array(...)` so any non-array decoded body falls back to `[]`.

## Reproduce (before this PR)

A controller returning `new JsonResponse('Hello World!')` causes:

```
TypeError: Treblle\Php\Helpers\SensitiveDataMasker::mask(): Argument #1 ($data) must be of type array, string given,
  called in vendor/treblle/treblle-symfony/src/DataProviders/SymfonyResponseDataProvider.php on line 87
```

## Change

```diff
             body: $masker->mask(
-                json_decode($body, true) ?? []
+                is_array($decoded = json_decode($body, true)) ? $decoded : []
             ),
```

## Test plan

- [ ] Controller returning `JsonResponse('foo')` no longer throws
- [ ] Controller returning `JsonResponse(['a' => 'b'])` masks/sends body as before
- [ ] Empty / 204 responses still produce empty body (decoded `null` → `[]`)