### PR TITLE
Custom Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ treblle:
     - creditScore
   excluded_paths: []          # Paths to skip (exact or wildcard)
   ingress_url: "https://ingress.treblle.com"  # Ingress endpoint
+  metadata: {}                # Key/Value metadata added to every request (user-id enables Customer Tracking)
 ```
 
 ### `sdk_token`
@@ -187,6 +188,24 @@ treblle:
   ingress_url: "https://ingress-eu.treblle.com"
 ```
 
+### `metadata`
+
+Key/Value metadata attached to every request. Useful for environment tags, region, tier, or any data you always want visible and searcable in Treblle.
+
+```yaml
+treblle:
+  metadata:
+    env: production
+    region: us-east-1
+    tier: enterprise
+```
+
+> **`user-id` is a reserved keyword.** When present in metadata, Treblle uses it to enable **Customer Tracking** — linking requests to individual users so you can filter, search, and analyse traffic per customer in the dashboard.
+
+See [Per-request metadata](#per-request-metadata) for adding dynamic values (e.g. the authenticated user's ID) at runtime.
+
+---
+
 ### `async`
 
 When `true`, the SDK dispatches payloads as Symfony Messenger messages instead of sending them inline. This moves the HTTP call to a background worker process, freeing your application immediately.
@@ -256,6 +275,45 @@ Run this as a supervised process (Supervisor, systemd, etc.) so it restarts auto
 **Fallback behaviour:**
 
 If `async: true` is set but `symfony/messenger` is not installed, the SDK silently falls back to the default synchronous send. No errors, no data loss - it just skips the queue.
+
+---
+
+## Per-request metadata
+
+Inject `MetadataRegistry` into any controller or service and call `add()` with an associative array. Values are merged with the globally defined metadata in YAML for that request only and cleared automatically after the response is sent.
+
+```php
+use Treblle\Symfony\Metadata\MetadataRegistry;
+
+final class OrderController extends AbstractController
+{
+    public function __construct(private readonly MetadataRegistry $treblle) {}
+
+    #[Route('/orders', methods: ['POST'])]
+    public function create(Request $request): JsonResponse
+    {
+        $this->treblle->add([
+            'user-id'  => $this->getUser()?->getId(),
+            'plan'     => 'enterprise',
+            'tenant'   => 'acme-corp',
+        ]);
+
+        // ... handle request
+    }
+}
+```
+
+Multiple calls within the same request are merged together:
+
+```php
+$this->treblle->add(['user-id' => 42]);
+$this->treblle->add(['plan' => 'pro']);
+// payload contains: { user-id: 42, plan: "pro" }
+```
+
+Runtime values take precedence over any static keys defined under `treblle.metadata` in your config — so you can set a sensible default in YAML and override it per-request when needed.
+
+> **Customer Tracking:** `user-id` is a reserved metadata keyword. When set, Treblle automatically links the request to that user in the dashboard, enabling per-customer traffic filtering, error tracking, and usage analysis.
 
 ---
 

--- a/pint.json
+++ b/pint.json
@@ -29,7 +29,6 @@
         "concat_space": {
             "spacing": "one"
         },
-        "arrow_function_spaces": true,
         "strict_comparison": true,
         "no_superfluous_elseif": true,
         "no_useless_else": true,

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -59,6 +59,12 @@ final class Configuration implements ConfigurationInterface
                     ->defaultFalse()
                     ->info('Dispatch payloads via Symfony Messenger instead of sending inline. Requires symfony/messenger with a Redis or AMQP transport.')
                 ->end()
+                ->arrayNode('metadata')
+                    ->normalizeKeys(false)
+                    ->variablePrototype()->end()
+                    ->defaultValue([])
+                    ->info('Static key-value pairs attached to every request payload under data.metadata. Use user_id to enable Customer tracking in Treblle.')
+                ->end()
             ->end()
         ->end();
 

--- a/src/DependencyInjection/TreblleConfiguration.php
+++ b/src/DependencyInjection/TreblleConfiguration.php
@@ -14,7 +14,9 @@ final readonly class TreblleConfiguration
         private array $excludedPaths = [],
         private string $ingressUrl = 'https://ingress.treblle.com',
         private bool $async = false,
-    ) {}
+        private array $metadata = [],
+    ) {
+    }
 
     public function isEnabled(): bool
     {
@@ -49,5 +51,10 @@ final readonly class TreblleConfiguration
     public function isAsync(): bool
     {
         return $this->async;
+    }
+
+    public function getMetadata(): array
+    {
+        return $this->metadata;
     }
 }

--- a/src/DependencyInjection/TreblleExtension.php
+++ b/src/DependencyInjection/TreblleExtension.php
@@ -44,6 +44,7 @@ final class TreblleExtension extends Extension implements PrependExtensionInterf
             '$excludedPaths' => (array) ($config['excluded_paths'] ?? []),
             '$ingressUrl' => $config['ingress_url'] ?? 'https://ingress.treblle.com',
             '$async' => (bool) ($config['async'] ?? false),
+            '$metadata' => (array) ($config['metadata'] ?? []),
         ]);
 
         $container->setDefinition(TreblleConfiguration::class, $definition);

--- a/src/Doctrine/TreblleMiddleware.php
+++ b/src/Doctrine/TreblleMiddleware.php
@@ -9,7 +9,9 @@ use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
 
 final class TreblleMiddleware implements MiddlewareInterface
 {
-    public function __construct(private readonly QueryCollector $collector) {}
+    public function __construct(private readonly QueryCollector $collector)
+    {
+    }
 
     public function wrap(DriverInterface $driver): DriverInterface
     {

--- a/src/Http/TreblleClient.php
+++ b/src/Http/TreblleClient.php
@@ -15,7 +15,8 @@ final class TreblleClient implements TreblleClientInterface
         private readonly TreblleConfiguration $configuration,
         private readonly CircuitBreaker $circuitBreaker,
         private readonly LoggerInterface $logger = new NullLogger(),
-    ) {}
+    ) {
+    }
 
     public function send(array $payload): void
     {

--- a/src/Messenger/SendTrebllePayload.php
+++ b/src/Messenger/SendTrebllePayload.php
@@ -8,5 +8,6 @@ final class SendTrebllePayload
 {
     public function __construct(
         public readonly array $payload,
-    ) {}
+    ) {
+    }
 }

--- a/src/Messenger/SendTrebllePayloadHandler.php
+++ b/src/Messenger/SendTrebllePayloadHandler.php
@@ -10,7 +10,8 @@ final class SendTrebllePayloadHandler
 {
     public function __construct(
         private readonly TreblleClient $client,
-    ) {}
+    ) {
+    }
 
     public function __invoke(SendTrebllePayload $message): void
     {

--- a/src/Metadata/MetadataRegistry.php
+++ b/src/Metadata/MetadataRegistry.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Symfony\Metadata;
+
+final class MetadataRegistry
+{
+    private array $metadata = [];
+
+    public function add(array $metadata): void
+    {
+        $this->metadata = array_merge($this->metadata, $metadata);
+    }
+
+    public function all(): array
+    {
+        return $this->metadata;
+    }
+
+    public function reset(): void
+    {
+        $this->metadata = [];
+    }
+}

--- a/src/Payload/PayloadBuilder.php
+++ b/src/Payload/PayloadBuilder.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Treblle\Symfony\Payload;
 
-use Throwable;
-use Treblle\Symfony\Doctrine\QueryCollector;
-use Treblle\Symfony\Masking\DataMasker;
-use Treblle\Symfony\TreblleBundle;
-use Treblle\Symfony\DependencyInjection\TreblleConfiguration;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use Treblle\Symfony\DependencyInjection\TreblleConfiguration;
+use Treblle\Symfony\Doctrine\QueryCollector;
+use Treblle\Symfony\Masking\DataMasker;
+use Treblle\Symfony\Metadata\MetadataRegistry;
+use Treblle\Symfony\TreblleBundle;
 
 final class PayloadBuilder
 {
@@ -21,7 +22,9 @@ final class PayloadBuilder
         private readonly TreblleConfiguration $configuration,
         private readonly DataMasker $masker,
         private readonly QueryCollector $queryCollector,
-    ) {}
+        private readonly MetadataRegistry $metadataRegistry,
+    ) {
+    }
 
     public function build(
         Request $request,
@@ -30,19 +33,30 @@ final class PayloadBuilder
         ?string $routePath,
         array $errors,
     ): array {
+        $metadata = array_merge(
+            $this->configuration->getMetadata(),
+            $this->metadataRegistry->all(),
+        );
+
+        $data = [
+            'server' => $this->buildServer(),
+            'language' => $this->buildLanguage(),
+            'request' => $this->buildRequest($request, $routePath),
+            'response' => $this->buildResponse($request, $response, $requestStartedAt, $errors),
+            'errors' => $errors,
+            'queries' => $this->queryCollector->all(),
+        ];
+
+        if ($metadata !== []) {
+            $data['metadata'] = $metadata;
+        }
+
         return [
             'sdk_token' => $this->configuration->getSdkToken(),
             'api_key' => $this->configuration->getApiKey(),
             'sdk' => TreblleBundle::SDK_NAME,
             'version' => TreblleBundle::SDK_VERSION,
-            'data' => [
-                'server' => $this->buildServer(),
-                'language' => $this->buildLanguage(),
-                'request' => $this->buildRequest($request, $routePath),
-                'response' => $this->buildResponse($request, $response, $requestStartedAt, $errors),
-                'errors' => $errors,
-                'queries' => $this->queryCollector->all(),
-            ],
+            'data' => $data,
         ];
     }
 

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -16,3 +16,5 @@ services:
     Treblle\Symfony\Routing\PathMatcher: ~
 
     Treblle\Symfony\Doctrine\QueryCollector: ~
+
+    Treblle\Symfony\Metadata\MetadataRegistry: ~

--- a/src/TreblleEventSubscriber.php
+++ b/src/TreblleEventSubscriber.php
@@ -6,13 +6,6 @@ namespace Treblle\Symfony;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Throwable;
-use Treblle\Symfony\DependencyInjection\TreblleConfiguration;
-use Treblle\Symfony\Doctrine\QueryCollector;
-use Treblle\Symfony\Http\TreblleClientInterface;
-use Treblle\Symfony\Messenger\SendTrebllePayload;
-use Treblle\Symfony\Payload\PayloadBuilder;
-use Treblle\Symfony\Routing\PathMatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,6 +15,14 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
+use Throwable;
+use Treblle\Symfony\DependencyInjection\TreblleConfiguration;
+use Treblle\Symfony\Doctrine\QueryCollector;
+use Treblle\Symfony\Http\TreblleClientInterface;
+use Treblle\Symfony\Messenger\SendTrebllePayload;
+use Treblle\Symfony\Metadata\MetadataRegistry;
+use Treblle\Symfony\Payload\PayloadBuilder;
+use Treblle\Symfony\Routing\PathMatcher;
 
 final class TreblleEventSubscriber implements EventSubscriberInterface
 {
@@ -41,8 +42,10 @@ final class TreblleEventSubscriber implements EventSubscriberInterface
         private readonly PathMatcher $pathMatcher,
         private readonly RouterInterface $router,
         private readonly QueryCollector $queryCollector,
+        private readonly MetadataRegistry $metadataRegistry,
         private readonly LoggerInterface $logger = new NullLogger(),
-    ) {}
+    ) {
+    }
 
     public function setMessageBus(object $messageBus): void
     {
@@ -204,6 +207,7 @@ final class TreblleEventSubscriber implements EventSubscriberInterface
         $this->response = null;
         $this->errors = [];
         $this->queryCollector->reset();
+        $this->metadataRegistry->reset();
     }
 
 }

--- a/tests/Payload/PayloadBuilderTest.php
+++ b/tests/Payload/PayloadBuilderTest.php
@@ -7,9 +7,10 @@ namespace Treblle\Symfony\Tests\Payload;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Treblle\Symfony\Doctrine\QueryCollector;
 use Treblle\Symfony\DependencyInjection\TreblleConfiguration;
+use Treblle\Symfony\Doctrine\QueryCollector;
 use Treblle\Symfony\Masking\DataMasker;
+use Treblle\Symfony\Metadata\MetadataRegistry;
 use Treblle\Symfony\Payload\PayloadBuilder;
 use Treblle\Symfony\TreblleBundle;
 
@@ -22,17 +23,19 @@ final class PayloadBuilderTest extends TestCase
         $this->builder = $this->makeBuilder();
     }
 
-    private function makeBuilder(array $maskedFields = []): PayloadBuilder
+    private function makeBuilder(array $maskedFields = [], array $configMetadata = [], ?MetadataRegistry $registry = null): PayloadBuilder
     {
         $config = new TreblleConfiguration(
             sdkToken: 'sdk-test-token',
             apiKey: 'api-test-key',
+            metadata: $configMetadata,
         );
 
         return new PayloadBuilder(
             configuration: $config,
             masker: new DataMasker($maskedFields),
             queryCollector: new QueryCollector(),
+            metadataRegistry: $registry ?? new MetadataRegistry(),
         );
     }
 
@@ -190,7 +193,7 @@ final class PayloadBuilderTest extends TestCase
         $collector = new QueryCollector();
         $collector->add('SELECT 1', 0.5);
 
-        $builder = new PayloadBuilder($config, new DataMasker(), $collector);
+        $builder = new PayloadBuilder($config, new DataMasker(), $collector, new MetadataRegistry());
         $payload = $builder->build(
             Request::create('/api/users', 'GET'),
             new Response('{}', 200, ['Content-Type' => 'application/json']),
@@ -201,5 +204,68 @@ final class PayloadBuilderTest extends TestCase
 
         $this->assertCount(1, $payload['data']['queries']);
         $this->assertSame('SELECT 1', $payload['data']['queries'][0]['sql']);
+    }
+
+    public function test_metadata_absent_when_empty(): void
+    {
+        $payload = $this->build(
+            Request::create('/api/users', 'GET'),
+            new Response('{}', 200, ['Content-Type' => 'application/json']),
+        );
+
+        $this->assertArrayNotHasKey('metadata', $payload['data']);
+    }
+
+    public function test_static_config_metadata_is_included(): void
+    {
+        $builder = $this->makeBuilder(configMetadata: ['env' => 'production', 'region' => 'us-east-1']);
+
+        $payload = $builder->build(
+            Request::create('/api/users', 'GET'),
+            new Response('{}', 200, ['Content-Type' => 'application/json']),
+            microtime(true),
+            null,
+            [],
+        );
+
+        $this->assertSame('production', $payload['data']['metadata']['env']);
+        $this->assertSame('us-east-1', $payload['data']['metadata']['region']);
+    }
+
+    public function test_runtime_metadata_is_included(): void
+    {
+        $registry = new MetadataRegistry();
+        $registry->add(['user_id' => 42, 'tenant' => 'acme']);
+
+        $builder = $this->makeBuilder(registry: $registry);
+
+        $payload = $builder->build(
+            Request::create('/api/users', 'GET'),
+            new Response('{}', 200, ['Content-Type' => 'application/json']),
+            microtime(true),
+            null,
+            [],
+        );
+
+        $this->assertSame(42, $payload['data']['metadata']['user_id']);
+        $this->assertSame('acme', $payload['data']['metadata']['tenant']);
+    }
+
+    public function test_runtime_metadata_overrides_config_metadata(): void
+    {
+        $registry = new MetadataRegistry();
+        $registry->add(['env' => 'staging']);
+
+        $builder = $this->makeBuilder(configMetadata: ['env' => 'production'], registry: $registry);
+
+        $payload = $builder->build(
+            Request::create('/api/users', 'GET'),
+            new Response('{}', 200, ['Content-Type' => 'application/json']),
+            microtime(true),
+            null,
+            [],
+        );
+
+        $this->assertSame('staging', $payload['data']['metadata']['env']);
     }
 }

--- a/tests/TreblleEventSubscriberTest.php
+++ b/tests/TreblleEventSubscriberTest.php
@@ -16,10 +16,11 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
-use Treblle\Symfony\Doctrine\QueryCollector;
 use Treblle\Symfony\DependencyInjection\TreblleConfiguration;
+use Treblle\Symfony\Doctrine\QueryCollector;
 use Treblle\Symfony\Http\TreblleClientInterface;
 use Treblle\Symfony\Masking\DataMasker;
+use Treblle\Symfony\Metadata\MetadataRegistry;
 use Treblle\Symfony\Payload\PayloadBuilder;
 use Treblle\Symfony\Routing\PathMatcher;
 use Treblle\Symfony\TreblleEventSubscriber;
@@ -139,14 +140,16 @@ final class TreblleEventSubscriberTest extends TestCase
         );
 
         $queryCollector = new QueryCollector();
+        $metadataRegistry = new MetadataRegistry();
 
         return new TreblleEventSubscriber(
             configuration: $config,
             client: $this->client,
-            payloadBuilder: new PayloadBuilder($config, new DataMasker(), $queryCollector),
+            payloadBuilder: new PayloadBuilder($config, new DataMasker(), $queryCollector, $metadataRegistry),
             pathMatcher: new PathMatcher(),
             router: $this->router,
             queryCollector: $queryCollector,
+            metadataRegistry: $metadataRegistry,
         );
     }
 


### PR DESCRIPTION
This update introduces the ability for custom metadata properties that can be defined globally or per-request. Custom Metadata allows you to tag requests with any key/value pair which will show up in the Treblle dashboard and you can search and filter based on it.